### PR TITLE
Utils/Kmett.hs: fix build failure agains ghc-7.10

### DIFF
--- a/Utils/Kmett.hs
+++ b/Utils/Kmett.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
 module Utils.Kmett (unzippedPara, mapValues) where
 
 import Control.Newtype


### PR DESCRIPTION
Fails as:

  [33 of 39] Compiling Utils.Kmett      ( Utils/Kmett.hs, dist/build/spl-hnc/spl-hnc-tmp/Utils/Kmett.dyn_o )
  Utils/Kmett.hs:16:1:
    Non type-variable argument
      in the constraint: Newtype (Tannen f p a b) (f (p a b))
    (Use FlexibleContexts to permit this)
    When checking that ‘mapValues’ has the inferred type
      mapValues :: forall o' (f :: * -> *) (p :: * -> * -> *) b c a.
                   (Newtype (Tannen f p a b) (f (p a b)), Newtype (Tannen f p a c) o',
                    Bifunctor (Tannen f p)) =>
                   (b -> c) -> f (p a b) -> o'

Signed-off-by: Sergei Trofimovich <siarheit@google.com>